### PR TITLE
Baseline de producción (06967fd) + herramientas de despliegue

### DIFF
--- a/.venv/pyvenv.cfg
+++ b/.venv/pyvenv.cfg
@@ -1,3 +1,0 @@
-home = /Users/javicanton/Library/Mobile Documents/com~apple~CloudDocs/Documents/Cursor/Telegram-app/.venv/bin
-include-system-site-packages = false
-version = 3.9.6

--- a/docker-compose.deploy-test.yml
+++ b/docker-compose.deploy-test.yml
@@ -1,0 +1,20 @@
+# Overlay: frontend se construye completo en Docker (no requiere carpeta frontend/build en el host).
+# Uso:
+#   docker compose -f docker-compose.yml -f docker-compose.deploy-test.yml up --build -d
+# Puerto por defecto 8080 para no chocar con otros servicios en 80.
+
+version: '3.8'
+
+services:
+  backend:
+    env_file:
+      - .env
+
+  frontend:
+    build:
+      context: ./frontend
+      dockerfile: Dockerfile.deploy
+      args:
+        REACT_APP_API_URL: /api
+    ports:
+      - "${FRONTEND_PORT:-8080}:80"

--- a/docker-compose.staging.yml
+++ b/docker-compose.staging.yml
@@ -1,0 +1,24 @@
+# Staging en paralelo a producción (mismo host, otro puerto y otro proyecto Compose).
+# Uso: ./scripts/deploy-staging.sh
+
+version: '3.8'
+
+services:
+  backend:
+    container_name: monitoria-staging-backend
+    env_file:
+      - .env
+
+  frontend:
+    container_name: monitoria-staging-frontend
+    build:
+      context: ./frontend
+      dockerfile: Dockerfile.deploy
+      args:
+        REACT_APP_API_URL: /api
+    ports:
+      - "${STAGING_FRONTEND_PORT:-8080}:80"
+
+  topic_worker:
+    profiles:
+      - with-worker

--- a/docs/BRANCHING.md
+++ b/docs/BRANCHING.md
@@ -1,0 +1,106 @@
+# Estrategia de ramas y despliegues
+
+## Resumen
+
+| Rama | URL / destino | Quién toca | Propósito |
+|------|----------------|------------|-----------|
+| **`production`** | https://app.monitoria.org | Solo merge vía PR aprobado | Lo que está en vivo |
+| **`cursor/staging-next-a92b`** | Puerto **8080** o `staging.app.monitoria.org` | Desarrollo diario | Login, SQL, nuevas features |
+| **`cursor/deploy-baseline-a92b`** | (histórica) | Archivada | Punto donde se creó el baseline; usar `production` |
+
+Tag inmutable de referencia: **`production-baseline-2026-02-17`** → commit `06967fd` (UI v0.33 desplegada en febrero).
+
+## Flujo de trabajo
+
+```
+cursor/staging-next-a92b  ──PR──►  production  ──deploy──►  app.monitoria.org :80
+        │
+        └── deploy-staging.sh ──►  :8080  (misma EC2, sin tocar producción)
+```
+
+1. **Nunca** commits directos en `production`.
+2. Trabajar en `cursor/staging-next-a92b` (o ramas `cursor/<feature>-a92b` creadas desde staging).
+3. Probar con `./scripts/deploy-staging.sh` en la instancia EC2 (puerto 8080).
+4. Cuando esté listo: PR `cursor/staging-next-a92b` → `production`, revisar, merge.
+5. En el servidor de producción: `git checkout production && git pull && ./scripts/deploy-local-test.sh --production`.
+
+## Proteger `production` en GitHub
+
+Si no está aplicado aún, en **Settings → Branches → Add rule**:
+
+- Branch name pattern: `production`
+- Require a pull request before merging
+- Require approvals: 1 (opcional)
+- Do not allow bypassing the above settings
+- Restrict who can push: solo maintainers (opcional)
+- **No** permitir force push ni borrado
+
+Desde CLI (mantenedor):
+
+```bash
+gh api repos/javicanton/monitor_IA/branches/production/protection \
+  --method PUT \
+  --input - <<'EOF'
+{
+  "required_status_checks": null,
+  "enforce_admins": true,
+  "required_pull_request_reviews": {
+    "dismiss_stale_reviews": true,
+    "require_code_owner_reviews": false,
+    "required_approving_review_count": 0
+  },
+  "restrictions": null,
+  "allow_force_pushes": false,
+  "allow_deletions": false
+}
+EOF
+```
+
+## Despliegue staging (puerto 8080)
+
+En la instancia **Monitor IA**, con producción ya corriendo en el puerto 80:
+
+```bash
+git fetch origin
+git checkout cursor/staging-next-a92b
+git pull
+./scripts/deploy-staging.sh
+```
+
+Comprobar: `http://<IP-EC2>:8080/` o configurar DNS `staging.app.monitoria.org` → misma IP.
+
+Parar solo staging (producción sigue en 80):
+
+```bash
+./scripts/deploy-staging.sh --down
+```
+
+## Despliegue producción
+
+Solo desde la rama `production`:
+
+```bash
+git checkout production
+git pull origin production
+./scripts/deploy-local-test.sh --production
+```
+
+## Rollback producción
+
+```bash
+git checkout production-baseline-2026-02-17
+./scripts/deploy-local-test.sh --production
+# Luego fijar production en ese commit con un PR de emergencia
+```
+
+## Crear una rama de feature
+
+```bash
+git fetch origin
+git checkout cursor/staging-next-a92b
+git pull
+git checkout -b cursor/mi-feature-a92b
+# ... commits ...
+git push -u origin cursor/mi-feature-a92b
+# PR hacia cursor/staging-next-a92b (no hacia production directamente)
+```

--- a/docs/DEPLOY_BASELINE.md
+++ b/docs/DEPLOY_BASELINE.md
@@ -1,0 +1,131 @@
+# Línea base de despliegue (app.monitoria.org)
+
+Este documento fija el **punto exacto** donde la web funciona igual que en producción (v0.33, gráfico temporal, búsqueda FTS, sin login obligatorio).
+
+## Referencia Git
+
+| Referencia | Commit | Notas |
+|------------|--------|--------|
+| Tag `production-baseline-2026-02-17` | `06967fd` | Coincide con `build-id.txt` en producción (`2026-02-17T12:55:59Z`) |
+| Rama de trabajo | `cursor/deploy-baseline-a92b` | Parte de ese commit; aquí se prueba el despliegue antes de publicar |
+
+La rama remota `scraper` **contiene** este commit y tiene 5 commits posteriores (mejoras del scraper). Para la UI idéntica a producción, usa **`06967fd`**, no necesariamente la punta de `scraper`.
+
+## Volver a este punto en tu máquina
+
+Si al hacer `git checkout` ves `M .venv/pyvenv.cfg`, es porque `.venv` estaba versionado por error. Solución:
+
+```bash
+git fetch origin
+git checkout cursor/deploy-baseline-a92b
+# Si sigue apareciendo .venv modificado:
+git restore .venv/pyvenv.cfg 2>/dev/null || rm -rf .venv
+```
+
+Alternativa por tag (solo lectura):
+
+```bash
+git fetch origin --tags
+git checkout production-baseline-2026-02-17
+```
+
+Desde `origin/scraper` sin perder la referencia:
+
+```bash
+git fetch origin
+git checkout -b mi-baseline origin/scraper
+git reset --hard 06967fd   # solo si quieres quedarte exactamente en producción
+```
+
+## Comprobar que es el mismo build que producción
+
+```bash
+curl -s https://app.monitoria.org/build-id.txt
+# Debe coincidir con frontend/public/build-id.txt tras npm run build en este commit
+```
+
+Versión en UI: **v 0.33 (en desarrollo)** (`frontend/src/config.js`).
+
+## Prueba de despliegue local (Docker)
+
+Requisitos: Docker, Docker Compose, credenciales AWS en `.env` (S3) para que el backend cargue mensajes.
+
+```bash
+cp credentials.example.txt .env   # editar AWS_* y JWT_SECRET_KEY
+./scripts/deploy-local-test.sh
+```
+
+Abre http://localhost (o el puerto indicado). Comprueba:
+
+- [ ] La página carga el dashboard y el logo
+- [ ] Aparece el gráfico «Evolución de mensajes»
+- [ ] «Buscar en mensajes» devuelve resultados
+- [ ] `curl -s http://localhost/api/health` → `{"status":"healthy"}`
+- [ ] `curl -s -X POST http://localhost/api/filter_messages -H "Content-Type: application/json" -d '{"page":1}'` → JSON con mensajes
+
+Parar:
+
+```bash
+docker compose -f docker-compose.yml -f docker-compose.deploy-test.yml down
+```
+
+## Despliegue en EC2 (Monitor IA)
+
+Instancia objetivo: **Monitor IA** (`eu-north-1`), la que sirve https://app.monitoria.org/
+
+### 1. En el servidor
+
+```bash
+cd /ruta/al/repo
+git fetch origin
+git checkout cursor/deploy-baseline-a92b
+git pull origin cursor/deploy-baseline-a92b
+```
+
+### 2. Variables de entorno
+
+Archivo `.env` en la raíz (no subir a Git):
+
+```bash
+AWS_ACCESS_KEY_ID=...
+AWS_SECRET_ACCESS_KEY=...
+AWS_REGION=eu-north-1
+S3_BUCKET=monitoria-data
+JWT_SECRET_KEY=...
+FRONTEND_PORT=80
+```
+
+### 3. Build y arranque
+
+```bash
+./scripts/deploy-local-test.sh --production
+# o manualmente:
+cd frontend && npm ci && npm run build && cd ..
+docker compose -f docker-compose.yml -f docker-compose.deploy-test.yml build
+docker compose -f docker-compose.yml -f docker-compose.deploy-test.yml up -d
+```
+
+### 4. Comprobación post-despliegue
+
+Igual que la lista local, contra `https://app.monitoria.org/`.
+
+### 5. Rollback
+
+```bash
+git checkout production-baseline-2026-02-17
+./scripts/deploy-local-test.sh --production
+```
+
+## Flujo recomendado hasta producción
+
+1. Trabajar solo en `cursor/deploy-baseline-a92b` (o ramas `cursor/*-a92b` creadas desde aquí).
+2. Cada cambio: prueba local con `deploy-local-test.sh`.
+3. Push y despliegue en EC2 de **staging** (mismo compose, otro puerto o subdominio) si lo tienes.
+4. Cuando todo pase checklist → merge a rama de despliegue y `up -d` en producción.
+5. **No** mezclar aún login/OAuth ni rama `database` hasta cerrar este baseline.
+
+## Qué viene después (fuera de este baseline)
+
+- Login sencillo (rama aparte desde este punto).
+- PostgreSQL para escalar datos (rama `database`).
+- Worker pytopicgram en la instancia detenida.

--- a/docs/DEPLOY_BASELINE.md
+++ b/docs/DEPLOY_BASELINE.md
@@ -7,7 +7,8 @@ Este documento fija el **punto exacto** donde la web funciona igual que en produ
 | Referencia | Commit | Notas |
 |------------|--------|--------|
 | Tag `production-baseline-2026-02-17` | `06967fd` | Coincide con `build-id.txt` en producción (`2026-02-17T12:55:59Z`) |
-| Rama de trabajo | `cursor/deploy-baseline-a92b` | Parte de ese commit; aquí se prueba el despliegue antes de publicar |
+| Rama **`production`** | protegida | Despliega en https://app.monitoria.org — ver [BRANCHING.md](BRANCHING.md) |
+| Rama **`cursor/staging-next-a92b`** | puerto 8080 | Desarrollo y pruebas sin tocar producción |
 
 La rama remota `scraper` **contiene** este commit y tiene 5 commits posteriores (mejoras del scraper). Para la UI idéntica a producción, usa **`06967fd`**, no necesariamente la punta de `scraper`.
 
@@ -116,13 +117,11 @@ git checkout production-baseline-2026-02-17
 ./scripts/deploy-local-test.sh --production
 ```
 
-## Flujo recomendado hasta producción
+## Flujo recomendado (ver [BRANCHING.md](BRANCHING.md))
 
-1. Trabajar solo en `cursor/deploy-baseline-a92b` (o ramas `cursor/*-a92b` creadas desde aquí).
-2. Cada cambio: prueba local con `deploy-local-test.sh`.
-3. Push y despliegue en EC2 de **staging** (mismo compose, otro puerto o subdominio) si lo tienes.
-4. Cuando todo pase checklist → merge a rama de despliegue y `up -d` en producción.
-5. **No** mezclar aún login/OAuth ni rama `database` hasta cerrar este baseline.
+1. **Producción** (`production`): solo actualizar vía PR aprobado → `./scripts/deploy-local-test.sh --production`.
+2. **Desarrollo** (`cursor/staging-next-a92b`): cambios nuevos → `./scripts/deploy-staging.sh` (puerto 8080).
+3. No mezclar login/OAuth ni rama `database` en `production` hasta validarlos en staging.
 
 ## Qué viene después (fuera de este baseline)
 

--- a/frontend/Dockerfile.deploy
+++ b/frontend/Dockerfile.deploy
@@ -1,0 +1,24 @@
+# Build + nginx en una sola imagen (pruebas de despliegue y EC2 sin npm en el host)
+FROM node:18.18.0-bullseye-slim AS build
+WORKDIR /app
+
+COPY package.json package-lock.json ./
+RUN npm install --omit=dev
+
+COPY . .
+
+ENV NODE_OPTIONS="--max-old-space-size=2048"
+ENV GENERATE_SOURCEMAP=false
+ENV DISABLE_ESLINT_PLUGIN=true
+ENV BROWSERSLIST_IGNORE_OLD_DATA=true
+ENV CI=false
+ARG REACT_APP_API_URL=/api
+ENV REACT_APP_API_URL=$REACT_APP_API_URL
+
+RUN npm run build
+
+FROM nginx:alpine
+WORKDIR /usr/share/nginx/html
+COPY --from=build /app/build /usr/share/nginx/html
+COPY nginx.conf /etc/nginx/conf.d/default.conf
+EXPOSE 80

--- a/scripts/deploy-local-test.sh
+++ b/scripts/deploy-local-test.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# Prueba de despliegue local o en EC2 (build Docker + compose up).
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT"
+
+PRODUCTION=false
+FRONTEND_PORT="${FRONTEND_PORT:-8080}"
+
+for arg in "$@"; do
+  case "$arg" in
+    --production) PRODUCTION=true; FRONTEND_PORT=80 ;;
+    -h|--help)
+      echo "Uso: $0 [--production]"
+      echo "  --production  expone el frontend en el puerto 80"
+      exit 0
+      ;;
+  esac
+done
+
+export FRONTEND_PORT
+
+if [[ ! -f .env ]]; then
+  echo "AVISO: no hay .env — el backend necesita AWS_* para cargar mensajes desde S3."
+  echo "       cp credentials.example.txt .env y edita las variables."
+fi
+
+echo "==> Build imágenes (backend + frontend)..."
+docker compose -f docker-compose.yml -f docker-compose.deploy-test.yml build
+
+echo "==> Arrancando servicios en puerto ${FRONTEND_PORT}..."
+docker compose -f docker-compose.yml -f docker-compose.deploy-test.yml up -d
+
+echo ""
+echo "Comprobaciones sugeridas:"
+echo "  curl -s http://localhost:${FRONTEND_PORT}/api/health"
+echo "  curl -s -X POST http://localhost:${FRONTEND_PORT}/api/filter_messages -H 'Content-Type: application/json' -d '{\"page\":1}' | head -c 200"
+echo ""
+echo "Abrir: http://localhost:${FRONTEND_PORT}/"
+echo "Parar: docker compose -f docker-compose.yml -f docker-compose.deploy-test.yml down"

--- a/scripts/deploy-staging.sh
+++ b/scripts/deploy-staging.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# Despliegue de staging (puerto 8080 por defecto). No detiene producción en :80.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT"
+
+COMPOSE_FILES=(-f docker-compose.yml -f docker-compose.deploy-test.yml -f docker-compose.staging.yml)
+PROJECT_NAME="${STAGING_PROJECT_NAME:-monitoria-staging}"
+STAGING_PORT="${STAGING_FRONTEND_PORT:-8080}"
+
+down=false
+for arg in "$@"; do
+  case "$arg" in
+    --down) down=true ;;
+    -h|--help)
+      echo "Uso: $0 [--down]"
+      echo "  Despliega staging en puerto ${STAGING_PORT} (proyecto Docker: ${PROJECT_NAME})"
+      exit 0
+      ;;
+  esac
+done
+
+export STAGING_FRONTEND_PORT="$STAGING_PORT"
+export FRONTEND_PORT="$STAGING_PORT"
+
+if $down; then
+  docker compose -p "$PROJECT_NAME" "${COMPOSE_FILES[@]}" down
+  echo "Staging detenido."
+  exit 0
+fi
+
+if [[ ! -f .env ]]; then
+  echo "AVISO: no hay .env — copia credentials.example.txt y configura AWS_*."
+fi
+
+echo "==> Build staging (${PROJECT_NAME})..."
+docker compose -p "$PROJECT_NAME" "${COMPOSE_FILES[@]}" build
+
+echo "==> Arrancando staging en puerto ${STAGING_PORT}..."
+docker compose -p "$PROJECT_NAME" "${COMPOSE_FILES[@]}" up -d
+
+echo ""
+echo "Staging listo (producción en :80 no se toca si usa otro proyecto compose)."
+echo "  http://localhost:${STAGING_PORT}/"
+echo "  curl -s http://localhost:${STAGING_PORT}/api/health"
+echo "Parar: $0 --down"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Objetivo

Fijar el baseline de producción y separar **producción** (app.monitoria.org) de **staging** (desarrollo en :8080).

## Ramas creadas

| Rama | Uso |
|------|-----|
| **`production`** | Despliegue en https://app.monitoria.org — debe protegerse en GitHub |
| **`cursor/staging-next-a92b`** | Desarrollo (login, SQL, etc.) → `./scripts/deploy-staging.sh` |
| Tag `production-baseline-2026-02-17` | Rollback inmutable a `06967fd` |

## Documentación

- `docs/BRANCHING.md` — flujo de trabajo y protección de rama
- `docs/DEPLOY_BASELINE.md` — despliegue y rollback

## Acción manual requerida

En GitHub → **Settings → Branches → Add rule** para `production`:
- Require pull request before merging
- Block force pushes
- Block deletions

## Despliegue staging en EC2

```bash
git checkout cursor/staging-next-a92b
./scripts/deploy-staging.sh   # puerto 8080, no toca :80
```

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4b51a561-41c1-4c8c-b3a5-c016c798a92b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4b51a561-41c1-4c8c-b3a5-c016c798a92b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

