### PR TITLE
Corregir búsqueda de texto y filtro por fechas (error 500)

### DIFF
--- a/backend/data_store.py
+++ b/backend/data_store.py
@@ -312,9 +312,7 @@ class DataStore:
         params: List = []
 
         if search_ids is not None:
-            if not search_ids:
-                clauses.append("1 = 0")
-            elif not search_via_join:
+            if not search_via_join:
                 placeholders = ", ".join(["?"] * len(search_ids))
                 clauses.append(f"cast(m.\"Message ID\" as BIGINT) IN ({placeholders})")
                 params.extend(search_ids)
@@ -397,6 +395,10 @@ class DataStore:
     def _prepare_query_parts(self, filters: Dict, has_topic_join: bool):
         search_query = self._search_query(filters)
         search_ids = self._search_ids(filters) if search_query else None
+        # FTS no encuentra tokens parciales (p. ej. "clim" vs "clima"); usar LIKE como en producción.
+        use_like_search = bool(search_query and (search_ids is None or len(search_ids) == 0))
+        if use_like_search:
+            search_ids = None
         search_via_join = bool(search_ids and len(search_ids) > _SEARCH_ID_IN_LIMIT)
         from_clause = self._build_from_clause(has_topic_join)
         if search_via_join:
@@ -405,7 +407,7 @@ class DataStore:
             filters,
             search_ids,
             has_topic_join,
-            search_query=search_query if search_ids is None else "",
+            search_query=search_query if use_like_search else "",
             search_via_join=search_via_join,
         )
         return from_clause, where_sql, params, search_ids, search_via_join

--- a/backend/data_store.py
+++ b/backend/data_store.py
@@ -12,6 +12,10 @@ from s3_client import get_s3_client
 
 logger = logging.getLogger(__name__)
 
+_DATE_COLUMN_CANDIDATES = ("Date Sent", "Date", "Creation Date")
+_TEXT_SEARCH_COLUMNS = ("Message Text", "Title", "Embed")
+_SEARCH_ID_IN_LIMIT = 500
+
 
 def _parse_s3_uri(value: Optional[str]) -> Tuple[Optional[str], Optional[str]]:
     if not value or not isinstance(value, str):
@@ -45,6 +49,7 @@ class DataStore:
         self.assignments_csv_path = os.path.join(self.cache_dir, "message_topics.csv")
         self.meta_path = os.path.join(self.cache_dir, "datastore_meta.json")
         self.lock = threading.Lock()
+        self._parquet_columns: Optional[set] = None
 
     def _ensure_cache_dir(self) -> None:
         os.makedirs(self.cache_dir, exist_ok=True)
@@ -182,6 +187,7 @@ class DataStore:
                 Config.TOPICS_ASSIGNMENTS_KEY, self.assignments_csv_path, meta, "topics_assignments"
             )
             self._write_meta(meta)
+            self._parquet_columns = None
             return self.messages_parquet_path
 
     def get_dataset_fingerprint(self) -> str:
@@ -197,13 +203,58 @@ class DataStore:
     def _connect(self):
         return duckdb.connect(database=":memory:")
 
+    def _get_parquet_columns(self) -> set:
+        if self._parquet_columns is not None:
+            return self._parquet_columns
+        parquet_path = self._quoted(self.ensure_local_parquet())
+        con = self._connect()
+        try:
+            rows = con.execute(f"DESCRIBE SELECT * FROM read_parquet('{parquet_path}')").fetchall()
+            self._parquet_columns = {row[0] for row in rows}
+            return self._parquet_columns
+        finally:
+            con.close()
+
     def _date_expr(self, alias: str = "m") -> str:
+        cols = [col for col in _DATE_COLUMN_CANDIDATES if col in self._get_parquet_columns()]
+        if not cols:
+            return "NULL::TIMESTAMP"
+        casts = [f"try_cast({alias}.\"{col}\" as TIMESTAMP)" for col in cols]
+        return casts[0] if len(casts) == 1 else f"coalesce({', '.join(casts)})"
+
+    @staticmethod
+    def _normalize_date_param(value) -> str:
+        if value in (None, ""):
+            return ""
+        return str(value).strip()[:10]
+
+    def _search_query(self, filters: Dict) -> str:
+        return (filters.get("search") or filters.get("q") or "").strip()
+
+    def _append_text_search_clause(self, clauses: List[str], params: List, search_query: str) -> None:
+        text_cols = [col for col in _TEXT_SEARCH_COLUMNS if col in self._get_parquet_columns()]
+        if not text_cols:
+            clauses.append("1 = 0")
+            return
+        terms = [term for term in search_query.split() if term.upper() not in ("AND", "OR", "NOT") and term.strip()]
+        if not terms:
+            terms = [search_query]
+        for term in terms:
+            pattern = f"%{term.lower()}%"
+            parts = [f"lower(coalesce(m.\"{col}\", '')) LIKE ?" for col in text_cols]
+            clauses.append(f"({' OR '.join(parts)})")
+            params.extend([pattern] * len(text_cols))
+
+    def _register_search_ids(self, con, search_ids: List[int]) -> None:
+        con.register(
+            "_search_ids_tmp",
+            pd.DataFrame({"message_id": [int(item) for item in search_ids]}),
+        )
+
+    def _append_search_join(self, from_clause: str) -> str:
         return (
-            f"coalesce("
-            f"try_cast({alias}.\"Date Sent\" as TIMESTAMP), "
-            f"try_cast({alias}.\"Date\" as TIMESTAMP), "
-            f"try_cast({alias}.\"Creation Date\" as TIMESTAMP)"
-            f")"
+            f"{from_clause} INNER JOIN _search_ids_tmp s"
+            f" ON cast(m.\"Message ID\" as BIGINT) = s.message_id"
         )
 
     def _normalize_topic_filter(self, topic_filter) -> List[int]:
@@ -223,7 +274,7 @@ class DataStore:
         return normalized
 
     def _search_ids(self, filters) -> Optional[List[int]]:
-        search_query = (filters.get("search") or filters.get("q") or "").strip()
+        search_query = self._search_query(filters)
         if not search_query:
             return None
         try:
@@ -233,7 +284,7 @@ class DataStore:
             ensure_index_synced_from_parquet(parquet_path, self.get_dataset_fingerprint())
             ids = search_message_ids(search_query)
             if ids is not None:
-                return ids
+                return [int(item) for item in ids]
         except Exception as exc:
             logger.warning("Búsqueda FTS no disponible: %s", exc)
         return None
@@ -249,17 +300,26 @@ class DataStore:
             )
         return from_clause
 
-    def _build_where_clause(self, filters: Dict, search_ids: Optional[List[int]], include_topics: bool) -> Tuple[str, List]:
+    def _build_where_clause(
+        self,
+        filters: Dict,
+        search_ids: Optional[List[int]],
+        include_topics: bool,
+        search_query: str = "",
+        search_via_join: bool = False,
+    ) -> Tuple[str, List]:
         clauses = []
         params: List = []
 
         if search_ids is not None:
             if not search_ids:
                 clauses.append("1 = 0")
-            else:
+            elif not search_via_join:
                 placeholders = ", ".join(["?"] * len(search_ids))
                 clauses.append(f"cast(m.\"Message ID\" as BIGINT) IN ({placeholders})")
                 params.extend(search_ids)
+        elif search_query:
+            self._append_text_search_clause(clauses, params, search_query)
 
         channel = filters.get("channel")
         if channel:
@@ -305,14 +365,14 @@ class DataStore:
                 clauses.append(f"lower(coalesce(m.\"Media Type\", '')) IN ({placeholders})")
                 params.extend(media_values)
 
-        date_start = filters.get("dateStart")
+        date_start = self._normalize_date_param(filters.get("dateStart"))
         if date_start:
-            clauses.append(f"date_trunc('day', {self._date_expr()}) >= date_trunc('day', cast(? as TIMESTAMP))")
+            clauses.append(f"CAST({self._date_expr()} AS DATE) >= CAST(? AS DATE)")
             params.append(date_start)
 
-        date_end = filters.get("dateEnd")
+        date_end = self._normalize_date_param(filters.get("dateEnd"))
         if date_end:
-            clauses.append(f"date_trunc('day', {self._date_expr()}) < date_trunc('day', cast(? as TIMESTAMP)) + INTERVAL 1 DAY")
+            clauses.append(f"CAST({self._date_expr()} AS DATE) <= CAST(? AS DATE)")
             params.append(date_end)
 
         where_sql = f" WHERE {' AND '.join(clauses)}" if clauses else ""
@@ -334,12 +394,27 @@ class DataStore:
             return os.path.exists(self.assignments_csv_path)
         return os.path.exists(self.assignments_csv_path)
 
-    def query_messages(self, filters: Dict, limit: int, offset: int) -> Tuple[pd.DataFrame, int]:
-        search_ids = self._search_ids(filters)
-        topic_filter = filters.get("topics") or filters.get("topic")
-        has_topic_join = self._has_topic_join(filters)
+    def _prepare_query_parts(self, filters: Dict, has_topic_join: bool):
+        search_query = self._search_query(filters)
+        search_ids = self._search_ids(filters) if search_query else None
+        search_via_join = bool(search_ids and len(search_ids) > _SEARCH_ID_IN_LIMIT)
         from_clause = self._build_from_clause(has_topic_join)
-        where_sql, params = self._build_where_clause(filters, search_ids, has_topic_join)
+        if search_via_join:
+            from_clause = self._append_search_join(from_clause)
+        where_sql, params = self._build_where_clause(
+            filters,
+            search_ids,
+            has_topic_join,
+            search_query=search_query if search_ids is None else "",
+            search_via_join=search_via_join,
+        )
+        return from_clause, where_sql, params, search_ids, search_via_join
+
+    def query_messages(self, filters: Dict, limit: int, offset: int) -> Tuple[pd.DataFrame, int]:
+        has_topic_join = self._has_topic_join(filters)
+        from_clause, where_sql, params, search_ids, search_via_join = self._prepare_query_parts(
+            filters, has_topic_join
+        )
         sort_sql = self._sort_clause(filters)
 
         topic_select = "cast(a.topic_id as BIGINT) as topic_id" if has_topic_join else "NULL::BIGINT as topic_id"
@@ -357,6 +432,8 @@ class DataStore:
 
         con = self._connect()
         try:
+            if search_via_join:
+                self._register_search_ids(con, search_ids)
             total = int(con.execute(count_sql, params).fetchone()[0])
             df = con.execute(query_sql, params + [limit, offset]).fetchdf()
             return df, total
@@ -375,10 +452,10 @@ class DataStore:
 
     def messages_over_time(self, filters: Dict) -> List[Dict]:
         filters = {k: v for k, v in (filters or {}).items() if k not in ("dateStart", "dateEnd")}
-        search_ids = self._search_ids(filters)
         has_topic_join = self._has_topic_join(filters)
-        from_clause = self._build_from_clause(has_topic_join)
-        where_sql, params = self._build_where_clause(filters, search_ids, has_topic_join)
+        from_clause, where_sql, params, search_ids, search_via_join = self._prepare_query_parts(
+            filters, has_topic_join
+        )
         date_expr = self._date_expr()
         day_expr = f"CAST(date_trunc('day', {date_expr}) AS DATE)"
 
@@ -396,6 +473,8 @@ class DataStore:
 
         con = self._connect()
         try:
+            if search_via_join:
+                self._register_search_ids(con, search_ids)
             rows = con.execute(sql, params).fetchall()
             return [
                 {"date": row[0].isoformat() if hasattr(row[0], "isoformat") else str(row[0]), "count": int(row[1])}
@@ -447,14 +526,19 @@ class DataStore:
         ]
 
     def export_filtered_dataframe(self, filters: Dict) -> pd.DataFrame:
-        search_ids = self._search_ids(filters)
         has_topic_join = self._has_topic_join(filters)
-        from_clause = self._build_from_clause(has_topic_join)
-        where_sql, params = self._build_where_clause(filters, search_ids, has_topic_join)
+        from_clause, where_sql, params, search_ids, search_via_join = self._prepare_query_parts(
+            filters, has_topic_join
+        )
         topic_select = "cast(a.topic_id as BIGINT) as topic_id" if has_topic_join else "NULL::BIGINT as topic_id"
+        views_expr = (
+            "coalesce(try_cast(m.\"Views\" as DOUBLE), 0)"
+            if "Views" in self._get_parquet_columns()
+            else "0::DOUBLE"
+        )
         sql = (
             "SELECT cast(m.\"Message ID\" as BIGINT) as \"Message ID\", m.\"Message Text\", m.\"Title\", "
-            f"{self._date_expr()} as \"Date Sent\", coalesce(try_cast(m.\"Views\" as DOUBLE), 0) as \"Views\", "
+            f"{self._date_expr()} as \"Date Sent\", {views_expr} as \"Views\", "
             "coalesce(try_cast(m.\"Score\" as DOUBLE), 0) as \"Score\", m.\"Label\", m.\"URL\", "
             "m.\"Media Type\", "
             f"{topic_select} "
@@ -462,6 +546,8 @@ class DataStore:
         )
         con = self._connect()
         try:
+            if search_via_join:
+                self._register_search_ids(con, search_ids)
             return con.execute(sql, params).fetchdf()
         finally:
             con.close()

--- a/backend/search_index.py
+++ b/backend/search_index.py
@@ -209,6 +209,15 @@ def search_message_ids(query: str) -> Optional[List[int]]:
                 (q,)
             )
             ids = [row[0] for row in cur.fetchall()]
+            if not ids and q and " " not in q and " AND " not in q.upper():
+                try:
+                    cur = conn.execute(
+                        f'SELECT message_id FROM {FTS_TABLE} WHERE {FTS_TABLE} MATCH ?',
+                        (f"{q}*",),
+                    )
+                    ids = [row[0] for row in cur.fetchall()]
+                except sqlite3.OperationalError:
+                    pass
             logger.info("search_index: búsqueda '%s' -> %d resultados", q[:50], len(ids))
             return ids
         except sqlite3.OperationalError as e:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problema

En staging (:8080), la búsqueda de texto y el filtro por fechas (desde la gráfica o los campos de fecha) devolvían error 500. Los demás filtros del menú lateral funcionaban correctamente.

Tras el primer fix, la búsqueda parcial seguía fallando: `"clim"` devolvía 0 resultados en staging mientras en producción devolvía 561.

## Causa

1. **Fechas**: `_date_expr()` referenciaba columnas (`Date`, `Creation Date`) que no existen en el parquet actual. DuckDB falla en tiempo de enlace aunque se use `try_cast`.
2. **Búsqueda (500)**: Los resultados FTS pueden devolver miles de IDs, generando cláusulas `IN` enormes que provocan fallos en DuckDB.
3. **Búsqueda (0 resultados)**: FTS5 solo coincide con tokens completos. `"clim"` no encuentra `"clima"` ni subcadenas; el backend interpretaba `[]` como "sin resultados" en lugar de hacer fallback `LIKE` como producción (`str.contains`).

## Solución

- Detectar columnas reales del parquet antes de construir expresiones de fecha.
- Comparar fechas con `CAST(... AS DATE)` usando formato `YYYY-MM-DD` del frontend.
- Para más de 500 IDs de búsqueda, usar `JOIN` con tabla temporal en DuckDB.
- Fallback `LIKE` en `Message Text`, `Title` y `Embed` cuando FTS no devuelve resultados.
- FTS prueba también prefijo `término*` para búsquedas de una sola palabra.

## Despliegue en EC2 (staging)

```bash
cd ~/monitor_IA
git fetch origin
git checkout desarrollo && git merge origin/cursor/fix-search-dates-a92b
./scripts/deploy-staging.sh
```

## Verificación

```bash
curl -X POST localhost:8080/api/filter_messages -H "Content-Type: application/json" \
  -d '{"page":1,"search":"clim"}'
curl -X POST localhost:8080/api/filter_messages -H "Content-Type: application/json" \
  -d '{"page":1,"dateStart":"2024-01-01","dateEnd":"2024-12-31"}'
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4b51a561-41c1-4c8c-b3a5-c016c798a92b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4b51a561-41c1-4c8c-b3a5-c016c798a92b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

