### PR TITLE
Evitar copiar datasets al build Docker del backend (sin espacio en disco)

### DIFF
--- a/backend/.dockerignore
+++ b/backend/.dockerignore
@@ -1,0 +1,29 @@
+# Datos locales: el contenedor carga desde S3 o volúmenes Docker en runtime
+*.csv
+*.parquet
+*.xlsx
+telegram_messages.json
+telegram_messages.*
+
+instance/
+cache/
+data/
+
+# Entornos y cachés de desarrollo
+.venv/
+venv/
+__pycache__/
+*.pyc
+.pytest_cache/
+.mypy_cache/
+
+# Git y secretos
+.git/
+.gitignore
+*.session
+*credentials*
+*Credentials*
+
+# Logs
+*.log
+logs/

--- a/scripts/deploy-staging.sh
+++ b/scripts/deploy-staging.sh
@@ -40,6 +40,19 @@ if [[ ! -f .env ]]; then
   fi
 fi
 
+echo "==> Espacio en disco (/)..."
+df -h / | tail -1
+
+echo "==> Liberando caché de build de Docker no usada..."
+docker builder prune -f --filter "until=48h" 2>/dev/null || true
+
+if [[ -f backend/telegram_messages.csv ]]; then
+  csv_size="$(du -h backend/telegram_messages.csv | cut -f1)"
+  echo "AVISO: backend/telegram_messages.csv (${csv_size}) está en el servidor pero NO se copia a la imagen."
+  echo "       Los datos se cargan desde S3 / volúmenes en runtime. Puedes borrarlo para liberar disco:"
+  echo "       rm -f backend/telegram_messages.csv"
+fi
+
 echo "==> Build staging (${PROJECT_NAME})..."
 docker compose -p "$PROJECT_NAME" "${COMPOSE_FILES[@]}" build
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problema

El build de staging fallaba en EC2:

```
failed to copy files: write /app/telegram_messages.csv: no space left on device
```

En el servidor suele existir `backend/telegram_messages.csv` (descargado para pruebas/importación). El `Dockerfile` hace `COPY . .` y, al no haber `.dockerignore` en backend, copia ese fichero enorme dentro de la imagen.

## Solución

- `backend/.dockerignore`: excluye CSV, parquet, JSON de datos, `instance/`, `cache/`, `data/`, venv, etc.
- `scripts/deploy-staging.sh`: muestra espacio en disco, limpia caché de build antigua y avisa si hay un CSV local.

Los datos en runtime siguen viniendo de S3 o de los volúmenes `staging-backend-cache` / `staging-backend-instance`.

## En EC2 (ahora, para desbloquear el build)

```bash
cd ~/monitor_IA
git fetch origin
git checkout desarrollo && git merge origin/cursor/fix-docker-build-space-a92b

# Liberar espacio (el CSV no hace falta en la imagen)
rm -f backend/telegram_messages.csv
docker builder prune -f
docker system prune -f   # solo si hace falta más espacio

./scripts/deploy-staging.sh
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4b51a561-41c1-4c8c-b3a5-c016c798a92b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4b51a561-41c1-4c8c-b3a5-c016c798a92b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

