### PR TITLE
Pytopicgram: narrativas con ventana de 7 días y deploy del worker

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -29,5 +29,18 @@ S3_BUCKET=monitoria-data
 # AWS_ACCESS_KEY_ID=
 # AWS_SECRET_ACCESS_KEY=
 
+# --- Worker pytopicgram (instancia EC2 separada) ---
+# TOPICS_DAYS_WINDOW=7
+# TOPICS_RESET_STATE=1
+# TOPICS_S3_PREFIX=topics/staging/
+# TOPICS_MODEL_KEY=topics/staging/model.pkl
+# TOPICS_STATE_KEY=topics/staging/state.json
+# TOPICS_META_KEY=topics/staging/topics.json
+# TOPICS_ASSIGNMENTS_KEY=topics/staging/message_topics.csv
+# TOPICS_NUM_TOPICS=50
+# TOPICS_SAMPLE_RATIO=0.3
+# TOPICS_OPENAI_KEY=
+# TOPIC_POLL_INTERVAL_MIN=1440
+
 JWT_SECRET_KEY=cambiar-en-produccion
 SECRET_KEY=cambiar-en-produccion

--- a/backend/config.py
+++ b/backend/config.py
@@ -76,6 +76,10 @@ class Config:
         TOPICS_SAMPLE_RATIO = float(_TOPICS_SAMPLE_RATIO_RAW) if _TOPICS_SAMPLE_RATIO_RAW else None
     except (TypeError, ValueError):
         TOPICS_SAMPLE_RATIO = None
+    # Ventana temporal: solo mensajes de los últimos N días (0 = sin límite). Pruebas: 7.
+    TOPICS_DAYS_WINDOW = int(os.environ.get('TOPICS_DAYS_WINDOW', 0))
+    # Si es true, ignora el estado incremental y reprocesa toda la ventana.
+    TOPICS_RESET_STATE = os.environ.get('TOPICS_RESET_STATE', '').lower() in ('1', 'true', 'yes')
     
     # Configuración de CORS
     CORS_HEADERS = 'Content-Type'

--- a/backend/data_store_pg.py
+++ b/backend/data_store_pg.py
@@ -180,8 +180,7 @@ class DataStorePG:
         search_query = self._search_query(filters)
         search_ids = self._search_ids(filters) if search_query else None
         use_like_search = bool(search_query and search_ids is None)
-        topic_filter = filters.get("topics") or filters.get("topic")
-        join_topics = bool(topic_filter)
+        join_topics = True
 
         q = db.session.query(
             Message.embed,
@@ -189,10 +188,9 @@ class DataStorePG:
             Message.message_id,
             Message.url,
             Message.label,
-            MessageTopic.topic_id if join_topics else cast(None, db.Integer).label("topic_id"),
+            MessageTopic.topic_id.label("topic_id"),
         )
-        if join_topics:
-            q = q.outerjoin(MessageTopic, Message.id == MessageTopic.message_id)
+        q = q.outerjoin(MessageTopic, Message.id == MessageTopic.message_id)
         q = q.join(Channel, Message.channel_id == Channel.id)
         q = self._apply_filters(q, filters, search_ids, join_topics, use_like_search=use_like_search)
         count_q = q.with_entities(func.count(distinct(Message.id)))
@@ -275,8 +273,7 @@ class DataStorePG:
         return [{"date": str(r.day), "count": r.count} for r in rows]
 
     def export_filtered_dataframe(self, filters: Dict) -> pd.DataFrame:
-        topic_filter = filters.get("topics") or filters.get("topic")
-        join_topics = bool(topic_filter)
+        join_topics = True
         search_query = self._search_query(filters)
         search_ids = self._search_ids(filters) if search_query else None
         use_like_search = bool(search_query and search_ids is None)
@@ -292,10 +289,9 @@ class DataStorePG:
             Message.url,
             Message.media_type,
             Message.average_views,
-            MessageTopic.topic_id if join_topics else cast(None, db.Integer).label("topic_id"),
+            MessageTopic.topic_id.label("topic_id"),
         )
-        if join_topics:
-            q = q.outerjoin(MessageTopic, Message.id == MessageTopic.message_id)
+        q = q.outerjoin(MessageTopic, Message.id == MessageTopic.message_id)
         q = q.join(Channel, Message.channel_id == Channel.id)
         q = self._apply_filters(q, filters, search_ids, join_topics, use_like_search=use_like_search)
         q = self._order_by(q, filters)

--- a/backend/topic_processor.py
+++ b/backend/topic_processor.py
@@ -5,7 +5,7 @@ import os
 import tempfile
 import subprocess
 import sys
-from datetime import datetime
+from datetime import datetime, timedelta
 
 import pandas as pd
 from botocore.exceptions import ClientError
@@ -24,6 +24,72 @@ def _safe_datetime(value):
         return pd.to_datetime(value).to_pydatetime()
     except Exception:
         return None
+
+
+def _message_date_column(df):
+    for col in ["Date Sent", "Date", "date_sent"]:
+        if col in df.columns:
+            return col
+    return None
+
+
+def _filter_by_days(df, days_window):
+    if not days_window or days_window <= 0 or df.empty:
+        return df
+    date_col = _message_date_column(df)
+    if not date_col:
+        logger.warning("TOPICS_DAYS_WINDOW activo pero no hay columna de fecha; sin filtrar")
+        return df
+    cutoff = datetime.utcnow() - timedelta(days=days_window)
+    dates = pd.to_datetime(df[date_col], errors="coerce", utc=True)
+    cutoff_ts = pd.Timestamp(cutoff, tz="UTC")
+    filtered = df[dates >= cutoff_ts]
+    logger.info(
+        "Ventana de %d días: %d -> %d mensajes",
+        days_window,
+        len(df),
+        len(filtered),
+    )
+    return filtered
+
+
+def _load_messages_from_postgres(days_window=None):
+    from sqlalchemy import func
+
+    from models import Message
+    from pg_upsert import create_app
+
+    app = create_app()
+    with app.app_context():
+        from models import db
+
+        date_expr = func.coalesce(Message.date_sent, Message.creation_date)
+        q = db.session.query(
+            Message.id.label("pg_id"),
+            Message.message_id.label("telegram_id"),
+            Message.message_text.label("message_text"),
+            date_expr.label("date_sent"),
+        ).filter(Message.message_text.isnot(None))
+
+        if days_window and days_window > 0:
+            cutoff = datetime.utcnow() - timedelta(days=days_window)
+            q = q.filter(date_expr >= cutoff)
+
+        rows = q.all()
+        if not rows:
+            return pd.DataFrame()
+
+        records = []
+        for row in rows:
+            records.append(
+                {
+                    "_pg_id": row.pg_id,
+                    "Message ID": row.telegram_id,
+                    "Message Text": row.message_text,
+                    "Date Sent": row.date_sent,
+                }
+            )
+        return pd.DataFrame(records)
 
 
 def _load_messages_df(s3_client):
@@ -221,12 +287,57 @@ def _upload_assignments(s3_client, assignments_df):
     s3_client.upload_dataframe(assignments_df, Config.TOPICS_ASSIGNMENTS_KEY, format="csv")
 
 
-def process_topics():
+def _save_assignments_to_postgres(target_df, topics):
+    """Persiste asignaciones en message_topics (PostgreSQL)."""
+    if "_pg_id" not in target_df.columns:
+        logger.warning("Sin columna _pg_id; no se escriben topics en PostgreSQL")
+        return 0
+
+    from models import MessageTopic
+    from pg_upsert import create_app
+
+    app = create_app()
+    written = 0
+    with app.app_context():
+        from models import db
+
+        pg_ids = target_df["_pg_id"].tolist()
+        MessageTopic.query.filter(MessageTopic.message_id.in_(pg_ids)).delete(
+            synchronize_session=False
+        )
+
+        for pg_id, topic_id in zip(pg_ids, topics):
+            try:
+                topic_id = int(topic_id)
+            except (TypeError, ValueError):
+                continue
+            if topic_id < 0:
+                continue
+            db.session.add(MessageTopic(message_id=int(pg_id), topic_id=topic_id))
+            written += 1
+
+        db.session.commit()
+    logger.info("Asignaciones guardadas en PostgreSQL: %d filas", written)
+    return written
+
+
+def process_topics(days_window=None):
     if importlib.util.find_spec("pytopicgram") is None:
         logger.error("pytopicgram no disponible en este contenedor")
         return {"status": "error", "error": "pytopicgram_not_installed"}
-    s3_client = get_s3_client()
-    df = _load_messages_df(s3_client)
+
+    days_window = days_window if days_window is not None else Config.TOPICS_DAYS_WINDOW
+    use_postgres = bool(os.environ.get("DATABASE_URL"))
+
+    if use_postgres:
+        logger.info("Cargando mensajes desde PostgreSQL (ventana: %s días)", days_window or "sin límite")
+        df = _load_messages_from_postgres(days_window)
+        s3_client = get_s3_client()
+    else:
+        s3_client = get_s3_client()
+        df = _load_messages_df(s3_client)
+        df = _filter_by_days(df, days_window)
+
     if df.empty:
         logger.info("No hay mensajes para procesar")
         return {"status": "empty"}
@@ -235,8 +346,8 @@ def process_topics():
     df = df.assign(_topic_text=docs_series)
     df = df[df["_topic_text"].str.len() > 0]
 
-    state = _load_state(s3_client)
-    new_df = _filter_new_messages(df, state)
+    state = {} if Config.TOPICS_RESET_STATE else _load_state(s3_client)
+    new_df = df if Config.TOPICS_RESET_STATE else _filter_new_messages(df, state)
 
     if new_df.empty:
         logger.info("No hay mensajes nuevos")
@@ -296,6 +407,8 @@ def process_topics():
 
         assignments = assignments.drop_duplicates(subset=["Message ID"], keep="last")
         _upload_assignments(s3_client, assignments)
+        if use_postgres:
+            _save_assignments_to_postgres(target_df, topics)
         _save_topics_metadata(s3_client, model)
         _save_state(s3_client, _state_from_df(df))
 
@@ -303,6 +416,8 @@ def process_topics():
         "status": "ok",
         "new_messages": int(len(new_df)),
         "retrained": bool(assign_full_dataset),
+        "days_window": days_window or None,
+        "postgres": use_postgres,
     }
 
 

--- a/backend/topic_worker.py
+++ b/backend/topic_worker.py
@@ -9,17 +9,17 @@ logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 
-def run_once():
-    result = process_topics()
+def run_once(days_window=None):
+    result = process_topics(days_window=days_window)
     logger.info(f"Ejecucion topics: {result}")
     return result
 
 
-def run_worker_loop(interval_min):
+def run_worker_loop(interval_min, days_window=None):
     logger.info(f"Worker topics activo cada {interval_min} min")
     while True:
         try:
-            run_once()
+            run_once(days_window=days_window)
         except Exception as e:
             logger.error(f"Error en worker topics: {e}")
         time.sleep(interval_min * 60)
@@ -29,12 +29,18 @@ def main():
     parser = argparse.ArgumentParser(description="Worker de topics")
     parser.add_argument("--once", action="store_true", help="Ejecutar una sola vez")
     parser.add_argument("--interval", type=int, default=Config.TOPIC_POLL_INTERVAL_MIN)
+    parser.add_argument(
+        "--days",
+        type=int,
+        default=None,
+        help="Solo mensajes de los últimos N días (sobreescribe TOPICS_DAYS_WINDOW)",
+    )
     args = parser.parse_args()
 
     if args.once:
-        run_once()
+        run_once(days_window=args.days)
     else:
-        run_worker_loop(args.interval)
+        run_worker_loop(args.interval, days_window=args.days)
 
 
 if __name__ == "__main__":

--- a/docker-compose.staging.yml
+++ b/docker-compose.staging.yml
@@ -5,6 +5,10 @@ services:
   backend:
     container_name: monitoria-staging-backend
     restart: unless-stopped
+    environment:
+      - TOPICS_META_KEY=${TOPICS_META_KEY:-topics/staging/topics.json}
+      - TOPICS_ASSIGNMENTS_KEY=${TOPICS_ASSIGNMENTS_KEY:-topics/staging/message_topics.csv}
+      - TOPICS_TITLES_KEY=${TOPICS_TITLES_KEY:-topics/staging/topic_titles.json}
     volumes:
       - staging-backend-cache:/app/data/cache
       - staging-backend-instance:/app/instance

--- a/docker-compose.worker.yml
+++ b/docker-compose.worker.yml
@@ -1,13 +1,28 @@
+# Worker pytopicgram en instancia EC2 separada (sin frontend/backend).
+# Uso: ./scripts/deploy-worker.sh [--once] [--days 7]
+
 services:
   topic_worker:
     build:
       context: ./backend
       dockerfile: Dockerfile.worker
+    container_name: monitoria-topic-worker
     command: ["python", "topic_worker.py"]
+    env_file:
+      - .env
     environment:
       - S3_BUCKET=${S3_BUCKET:-monitoria-data}
       - AWS_REGION=${AWS_REGION:-eu-north-1}
+      - DATABASE_URL=${DATABASE_URL:-}
       - TOPIC_POLL_INTERVAL_MIN=${TOPIC_POLL_INTERVAL_MIN:-1440}
       - TOPICS_NUM_TOPICS=${TOPICS_NUM_TOPICS:-50}
       - TOPICS_SAMPLE_RATIO=${TOPICS_SAMPLE_RATIO:-0.3}
+      - TOPICS_DAYS_WINDOW=${TOPICS_DAYS_WINDOW:-7}
+      - TOPICS_RESET_STATE=${TOPICS_RESET_STATE:-1}
+      - TOPICS_S3_PREFIX=${TOPICS_S3_PREFIX:-topics/staging/}
+      - TOPICS_MODEL_KEY=${TOPICS_MODEL_KEY:-topics/staging/model.pkl}
+      - TOPICS_STATE_KEY=${TOPICS_STATE_KEY:-topics/staging/state.json}
+      - TOPICS_META_KEY=${TOPICS_META_KEY:-topics/staging/topics.json}
+      - TOPICS_ASSIGNMENTS_KEY=${TOPICS_ASSIGNMENTS_KEY:-topics/staging/message_topics.csv}
+      - TOPICS_OPENAI_KEY=${TOPICS_OPENAI_KEY:-}
     restart: unless-stopped

--- a/scripts/deploy-worker.sh
+++ b/scripts/deploy-worker.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# Despliega el worker pytopicgram en la instancia EC2 dedicada (sin tocar app :80 ni staging :8080).
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT"
+
+ONCE=false
+DAYS="${TOPICS_DAYS_WINDOW:-7}"
+DOWN=false
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --once) ONCE=true; shift ;;
+    --down) DOWN=true; shift ;;
+    --days=*) DAYS="${1#*=}"; shift ;;
+    --days) DAYS="${2:-7}"; shift 2 ;;
+    -h|--help)
+      cat <<EOF
+Uso: $0 [--once] [--days N] [--down]
+
+  Despliega topic_worker con docker-compose.worker.yml en esta instancia.
+  Por defecto procesa solo los últimos 7 días (TOPICS_DAYS_WINDOW).
+
+  --once     Ejecuta una pasada y sale (no deja el bucle activo)
+  --days N   Ventana temporal en días (pruebas: 7)
+  --down     Detiene el contenedor del worker
+
+Variables útiles en .env:
+  DATABASE_URL          PostgreSQL (mensajes + message_topics)
+  TOPICS_RESET_STATE=1  Reprocesar toda la ventana (recomendado en pruebas)
+  TOPICS_S3_PREFIX      Prefijo S3 para modelo/asignaciones (p. ej. topics/staging/)
+EOF
+      exit 0
+      ;;
+    *) echo "Opción desconocida: $1"; exit 1 ;;
+  esac
+done
+
+export DOCKER_BUILDKIT=1
+export COMPOSE_DOCKER_CLI_BUILD=1
+export TOPICS_DAYS_WINDOW="$DAYS"
+
+if [[ -f .env ]]; then
+  set -a
+  # shellcheck disable=SC1091
+  source .env
+  set +a
+fi
+
+COMPOSE=(docker compose -f docker-compose.worker.yml)
+
+if $DOWN; then
+  "${COMPOSE[@]}" down
+  echo "Worker de topics detenido."
+  exit 0
+fi
+
+echo "==> Build topic_worker (pytopicgram + PyTorch CPU; puede tardar varios minutos)..."
+"${COMPOSE[@]}" build --progress=plain topic_worker
+
+if $ONCE; then
+  echo "==> Ejecución única (--once), ventana ${DAYS} días..."
+  "${COMPOSE[@]}" run --rm \
+    -e TOPICS_DAYS_WINDOW="$DAYS" \
+    topic_worker python topic_worker.py --once --days "$DAYS"
+  echo "Listo. Revisa logs y S3 (${TOPICS_S3_PREFIX:-topics/staging/})."
+  exit 0
+fi
+
+echo "==> Arrancando worker en bucle (intervalo ${TOPIC_POLL_INTERVAL_MIN:-1440} min)..."
+"${COMPOSE[@]}" up -d topic_worker
+echo ""
+echo "Worker activo. Logs:"
+echo "  docker logs -f monitoria-topic-worker"
+echo "Ejecución manual:"
+echo "  $0 --once --days ${DAYS}"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Resumen

Preparación para ejecutar **pytopicgram** en la instancia EC2 del worker (separada de app :80 y staging :8080), usando solo mensajes de la **última semana** en las pruebas iniciales.

## Cambios

- **`topic_processor.py`**: lee mensajes desde PostgreSQL (`DATABASE_URL`) o S3; filtra por `TOPICS_DAYS_WINDOW`; escribe asignaciones en `message_topics` y en S3.
- **`topic_worker.py`**: argumentos `--days` y `--once` para ejecución manual de prueba.
- **`data_store_pg.py`**: muestra `topic_id` en listados aunque no se filtre por narrativa.
- **`scripts/deploy-worker.sh`**: despliegue del worker en la instancia dedicada.
- **`docker-compose.worker.yml`**: variables por defecto para pruebas (`TOPICS_DAYS_WINDOW=7`, prefijo `topics/staging/`).
- **`docker-compose.staging.yml`**: backend staging lee metadatos de topics desde `topics/staging/`.

## Despliegue en la instancia del worker

```bash
cd ~/monitor_IA
git fetch origin
git checkout desarrollo
git merge origin/cursor/pytopicgram-last-week-152e   # tras merge del PR
# .env debe incluir DATABASE_URL (mismo RDS que staging)
./scripts/deploy-worker.sh --once --days 7
```

Para dejar el worker en bucle diario:

```bash
./scripts/deploy-worker.sh
```

## Despliegue staging (para ver narrativas en :8080)

```bash
git checkout desarrollo && git pull
./scripts/deploy-staging.sh --host-frontend
```

Tras ejecutar el worker, comprobar en http://localhost:8080/ que los mensajes muestran narrativa y que el filtro de temas funciona.

## Variables relevantes (`.env` del worker)

| Variable | Valor prueba |
|----------|----------------|
| `DATABASE_URL` | RDS compartido con staging |
| `TOPICS_DAYS_WINDOW` | `7` |
| `TOPICS_RESET_STATE` | `1` (reprocesar toda la ventana) |
| `TOPICS_S3_PREFIX` | `topics/staging/` |
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-266fc046-d32f-4636-af7b-b6b9f263152e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-266fc046-d32f-4636-af7b-b6b9f263152e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

