### PR TITLE
Fix 504 en búsqueda: aplicar FTS en la query + asegurar índice GIN

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -83,6 +83,13 @@ with app.app_context():
         db.create_all()
     except Exception as exc:
         logger.warning("db.create_all no completó al arrancar (la API /health sigue activa): %s", exc)
+    try:
+        if USE_POSTGRES:
+            from search_index_pg import ensure_pg_fts_index
+
+            ensure_pg_fts_index()
+    except Exception as exc:
+        logger.warning("No se pudo inicializar índice FTS de PostgreSQL: %s", exc)
 
 # Caché en memoria solo cuando no se usa PostgreSQL (path DuckDB/JSON)
 _DATA_CACHE = None

--- a/backend/data_store_pg.py
+++ b/backend/data_store_pg.py
@@ -63,6 +63,30 @@ class DataStorePG:
     def _search_query(self, filters: Dict) -> str:
         return (filters.get("search") or filters.get("q") or "").strip()
 
+    def _apply_pg_fts_search(self, q, search_query: str):
+        """
+        Aplica full-text search (PostgreSQL) directamente sobre la query principal.
+        Evita traer listas grandes de IDs a Python (que puede provocar timeouts/504).
+        """
+        from search_boolean import has_boolean_operators, parse_boolean_search, parsed_to_tsquery
+
+        raw = (search_query or "").strip()
+        if not raw:
+            return q
+
+        # Nota: aquí referenciamos la tabla real `messages` (no alias `m`).
+        vector = "to_tsvector('spanish', coalesce(messages.message_text, '') || ' ' || coalesce(messages.url, ''))"
+        try:
+            if has_boolean_operators(raw):
+                parsed = parse_boolean_search(raw)
+                tsq = parsed_to_tsquery(parsed) if parsed else None
+                if tsq:
+                    return q.filter(text(f"{vector} @@ to_tsquery('spanish', :tsq)")).params(tsq=tsq)
+            return q.filter(text(f"{vector} @@ plainto_tsquery('spanish', :fts_q)")).params(fts_q=raw)
+        except Exception as exc:
+            logger.warning("FTS PostgreSQL falló; usando ILIKE (%s)", exc)
+            return self._apply_text_search(q, raw)
+
     def _search_ids(self, filters: Dict) -> Optional[List[int]]:
         search_query = self._search_query(filters)
         if not search_query:
@@ -115,8 +139,9 @@ class DataStorePG:
         search_query = self._search_query(filters)
         if search_ids is not None:
             q = q.filter(Message.id.in_(search_ids))
-        elif use_like_search and search_query:
-            q = self._apply_text_search(q, search_query)
+        elif search_query:
+            # Preferir FTS (PostgreSQL) por rendimiento; fallback a ILIKE si se fuerza.
+            q = self._apply_text_search(q, search_query) if use_like_search else self._apply_pg_fts_search(q, search_query)
         channel = filters.get("channel")
         if channel:
             if isinstance(channel, list):
@@ -186,9 +211,8 @@ class DataStorePG:
     def query_messages(self, filters: Dict, limit: int, offset: int) -> Tuple[pd.DataFrame, int]:
         limit = min(max(1, limit), MAX_PAGE_SIZE)
         offset = max(0, offset)
-        search_query = self._search_query(filters)
-        search_ids = self._search_ids(filters) if search_query else None
-        use_like_search = bool(search_query and search_ids is None)
+        search_ids = None
+        use_like_search = False
         topic_filter = filters.get("topics") or filters.get("topic")
         join_topics = bool(topic_filter)
 
@@ -274,9 +298,8 @@ class DataStorePG:
 
     def messages_over_time(self, filters: Dict) -> List[Dict]:
         filters = dict(filters or {})
-        search_query = self._search_query(filters)
-        search_ids = self._search_ids(filters) if search_query else None
-        use_like_search = bool(search_query and search_ids is None)
+        search_ids = None
+        use_like_search = False
         topic_filter = filters.get("topics") or filters.get("topic")
         join_topics = bool(topic_filter)
 
@@ -295,9 +318,8 @@ class DataStorePG:
     def export_filtered_dataframe(self, filters: Dict) -> pd.DataFrame:
         topic_filter = filters.get("topics") or filters.get("topic")
         join_topics = bool(topic_filter)
-        search_query = self._search_query(filters)
-        search_ids = self._search_ids(filters) if search_query else None
-        use_like_search = bool(search_query and search_ids is None)
+        search_ids = None
+        use_like_search = False
 
         q = db.session.query(
             Message.message_id,

--- a/backend/search_index_pg.py
+++ b/backend/search_index_pg.py
@@ -16,6 +16,32 @@ logger = logging.getLogger(__name__)
 
 _VECTOR = "to_tsvector('spanish', coalesce(m.message_text, '') || ' ' || coalesce(m.url, ''))"
 
+_INDEX_NAME = "messages_fts_spanish_gin_idx"
+
+
+def ensure_pg_fts_index() -> None:
+    """
+    Asegura un índice GIN para la búsqueda full-text.
+    Sin este índice, la búsqueda puede hacer seq-scan y causar timeouts (504) en staging.
+    """
+    from models import db
+
+    try:
+        # Evitar usar CONCURRENTLY (requiere autocommit y no es IF NOT EXISTS en todas las versiones).
+        db.session.execute(
+            text(
+                f"""
+                CREATE INDEX IF NOT EXISTS {_INDEX_NAME}
+                ON messages
+                USING GIN (to_tsvector('spanish', coalesce(message_text, '') || ' ' || coalesce(url, '')));
+                """
+            )
+        )
+        db.session.commit()
+    except Exception as exc:
+        db.session.rollback()
+        logger.warning("No se pudo asegurar el índice FTS (%s): %s", _INDEX_NAME, exc)
+
 
 def search_message_row_ids_pg(query: str) -> Optional[List[int]]:
     """


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problema

La búsqueda de texto (filtro `search`) en `POST /api/filter_messages` en staging acababa en **timeout (504)**.

## Causa

- El backend hacía un `SELECT ...` para traer **todos** los IDs coincidentes con FTS a Python y luego aplicaba `WHERE messages.id IN (...)`.
- Para términos frecuentes, esa lista puede ser enorme y/o sin índice FTS provocar **seq-scan**, excediendo el timeout del proxy.

## Solución

- Aplicar la condición FTS (**`to_tsvector @@ plainto_tsquery/to_tsquery`**) directamente en la query principal (paginada), evitando listas gigantes de IDs.
- Asegurar al arranque un índice **GIN** para esa expresión FTS (`CREATE INDEX IF NOT EXISTS ...`).
- Mantener fallback a ILIKE si FTS falla.

## Verificación

En staging, tras desplegar:

```bash
curl -m 20 -s -X POST http://localhost:8080/api/filter_messages \
  -H 'Content-Type: application/json' -d '{"page":1,"search":"gobierno"}' | head -c 200
```

Debe responder rápido con `success: true` (sin 504).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4b51a561-41c1-4c8c-b3a5-c016c798a92b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4b51a561-41c1-4c8c-b3a5-c016c798a92b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

